### PR TITLE
CMake fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ catkin_package(
 
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
-include_directories(include)
+include_directories(${catkin_INCLUDE_DIRS})
 
 ## Declare a C++ executable
 add_executable(loop loop.cpp)


### PR DESCRIPTION
Small change to add catkin_INCLUDE_DIRS to include_directories
to fix `fatal error: ros/ros.h: No such file or directory`